### PR TITLE
Fixing hx-disabled-elt attribute.

### DIFF
--- a/snippets/htmx-add-html.json
+++ b/snippets/htmx-add-html.json
@@ -29,10 +29,10 @@
       "https://htmx.org/attributes/hx-disable/"
     ]
   },
-  "hx-disable-elt": {
-    "prefix": "hx-disable-elt",
+  "hx-disabled-elt": {
+    "prefix": "hx-disabled-elt",
     "body": [
-      "hx-disable-elt=\"${1:this}\""
+      "hx-disabled-elt=\"${1:this}\""
     ],
     "description": [
       "adds the disabled attribute to the specified elements while a request is in flight\n",

--- a/snippets/htmx-add-jsx.json
+++ b/snippets/htmx-add-jsx.json
@@ -29,10 +29,10 @@
       "https://htmx.org/attributes/hx-disable/"
     ]
   },
-  "hx-disable-elt": {
-    "prefix": "hx-disable-elt",
+  "hx-disabled-elt": {
+    "prefix": "hx-disabled-elt",
     "body": [
-      "hx-disable-elt=\"${1:this}\""
+      "hx-disabled-elt=\"${1:this}\""
     ],
     "description": [
       "adds the disabled attribute to the specified elements while a request is in flight\n",

--- a/snippets/htmx-add-templ.json
+++ b/snippets/htmx-add-templ.json
@@ -29,10 +29,10 @@
       "https://htmx.org/attributes/hx-disable/"
     ]
   },
-  "hx-disable-elt": {
-    "prefix": "hx-disable-elt",
+  "hx-disabled-elt": {
+    "prefix": "hx-disabled-elt",
     "body": [
-      "hx-disable-elt=\"${1:this}\""
+      "hx-disabled-elt=\"${1:this}\""
     ],
     "description": [
       "adds the disabled attribute to the specified elements while a request is in flight\n",

--- a/tests/go.templ
+++ b/tests/go.templ
@@ -6,7 +6,7 @@ templ hello(name string) {
         hx-confirm=""
         hx-delete=""
         hx-disable
-        hx-disable-elt="this"
+        hx-disabled-elt="this"
         hx-disinherit="*"
         hx-encoding
         hx-ext=""

--- a/tests/test.html
+++ b/tests/test.html
@@ -11,7 +11,7 @@
     hx-confirm=""
     hx-delete=""
     hx-disable
-    hx-disable-elt="this"
+    hx-disabled-elt="this"
     hx-disinherit="*"
     hx-encoding
     hx-ext=""

--- a/tests/test.jsx
+++ b/tests/test.jsx
@@ -16,7 +16,7 @@ export default function test(test) {
             hx-confirm=""
             hx-delete=""
             hx-disable
-            hx-disable-elt="this"
+            hx-disabled-elt="this"
             hx-disinherit="*"
             hx-encoding
             hx-ext=""

--- a/tests/test.php
+++ b/tests/test.php
@@ -12,7 +12,7 @@
     hx-confirm=""
     hx-delete=""
     hx-disable
-    hx-disable-elt="this"
+    hx-disabled-elt="this"
     hx-disinherit="*"
     hx-encoding
     hx-ext=""

--- a/tests/tsx.tsx
+++ b/tests/tsx.tsx
@@ -16,7 +16,7 @@ export default function test(test: any) {
             hx-confirm=""
             hx-delete=""
             hx-disable
-            hx-disable-elt="this"
+            hx-disabled-elt="this"
             hx-disinherit="*"
             hx-encoding
             hx-ext=""


### PR DESCRIPTION
# Description.
Fixing typo on `hx-disabled-elt`. According to [docs](https://htmx.org/attributes/hx-disabled-elt/) it has to end with "d". 

![image](https://github.com/CRBroughton/htmx-attributes/assets/3083587/326e2326-6d1d-458e-a53a-53bb5082ba23)


