### PR TITLE
Add `hx-swap-oob` support

### DIFF
--- a/snippets/htmx-core-html.json
+++ b/snippets/htmx-core-html.json
@@ -81,6 +81,16 @@
       "https://htmx.org/attributes/hx-swap/"
     ]
   },
+  "hx-swap-oob": {
+    "prefix": "hx-swap-oob",
+    "body": [
+      "hx-swap-oob=\"${01}\""
+    ],
+    "description": [
+      "controls how content is swapped in (outerHTML, beforeend, afterend, …), out of band (somewhere other than the target)\n",
+      "https://htmx.org/attributes/hx-swap-oob/"
+    ]
+  },
   "hx-target": {
     "prefix": "hx-target",
     "body": [

--- a/snippets/htmx-core-jsx.json
+++ b/snippets/htmx-core-jsx.json
@@ -81,6 +81,16 @@
       "https://htmx.org/attributes/hx-swap/"
     ]
   },
+  "hx-swap-oob": {
+    "prefix": "hx-swap-oob",
+    "body": [
+      "hx-swap-oob=\"${01}\""
+    ],
+    "description": [
+      "controls how content is swapped in (outerHTML, beforeend, afterend, …), out of band (somewhere other than the target)\n",
+      "https://htmx.org/attributes/hx-swap-oob/"
+    ]
+  },
   "hx-target": {
     "prefix": "hx-target",
     "body": [

--- a/snippets/htmx-core-templ.json
+++ b/snippets/htmx-core-templ.json
@@ -81,6 +81,16 @@
       "https://htmx.org/attributes/hx-swap/"
     ]
   },
+  "hx-swap-oob": {
+    "prefix": "hx-swap-oob",
+    "body": [
+      "hx-swap-oob=\"${01}\""
+    ],
+    "description": [
+      "controls how content is swapped in (outerHTML, beforeend, afterend, …), out of band (somewhere other than the target)\n",
+      "https://htmx.org/attributes/hx-swap-oob/"
+    ]
+  },
   "hx-target": {
     "prefix": "hx-target",
     "body": [

--- a/tests/go.templ
+++ b/tests/go.templ
@@ -30,6 +30,7 @@ templ hello(name string) {
         hx-select=""
         hx-select-oob=""
         hx-swap=""
+        hx-swap-oob=""
         hx-sync=""
         hx-target=""
         hx-trigger=""

--- a/tests/test.html
+++ b/tests/test.html
@@ -33,6 +33,7 @@
     hx-request=''
     hx-select=""
     hx-swap=""
+    hx-swap-oob=""
     hx-sync=""
     hx-target=""
     hx-trigger=""

--- a/tests/test.jsx
+++ b/tests/test.jsx
@@ -9,6 +9,7 @@ export default function test(test) {
             hx-select="true"
             hx-select-oob="true"
             hx-swap="true"
+            hx-swap-oob="true"
             hx-target="true"
             hx-trigger="true"
             hx-vals='{"myVal": "My Value"}'

--- a/tests/test.php
+++ b/tests/test.php
@@ -34,6 +34,7 @@
     hx-request=''
     hx-select=""
     hx-swap=""
+    hx-swap-oob=""
     hx-sync=""
     hx-target=""
     hx-trigger=""

--- a/tests/tsx.tsx
+++ b/tests/tsx.tsx
@@ -9,6 +9,7 @@ export default function test(test: any) {
             hx-select="true"
             hx-select-oob="true"
             hx-swap="true"
+            hx-swap-oob="true"
             hx-target="true"
             hx-trigger="true"
             hx-vals='{"myVal": "My Value"}'


### PR DESCRIPTION
Adding support for [hx-swap-oob](https://htmx.org/attributes/hx-swap-oob/):

<img width="611" alt="Screenshot 2024-03-15 at 21 36 36" src="https://github.com/CRBroughton/htmx-attributes/assets/131331/e599ec7b-57c3-4aa5-ac25-a1c7e6a9ab30">