### PR TITLE
Add django-html and jinja-html languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,22 @@
         "path": "./snippets/htmx-add-html.json"
       },
       {
+        "language": "django-html",
+        "path": "./snippets/htmx-core-html.json"
+      },
+      {
+        "language": "django-html",
+        "path": "./snippets/htmx-add-html.json"
+      },
+      {
+        "language": "jinja-html",
+        "path": "./snippets/htmx-core-html.json"
+      },
+      {
+        "language": "jinja-html",
+        "path": "./snippets/htmx-add-html.json"
+      },
+      {
         "language": "javascriptreact",
         "path": "./snippets/htmx-core-jsx.json"
       },


### PR DESCRIPTION
Fixes #4

Nothing magic about the Django/Jinja2 templates, they're just html with some macro/templating logic around.

The hx-* tabcomplete is available in the entiere file, not just inside html tags, but that is true for plain html files too, so that isn't a "regression".

There isn't much to test, but if you do want to test it should be sufficient to install the `samuelcolvin.jinjahtml` and or `batisteo.vscode-django` extensions.
You can use the following Jinja example (it is also a valid Django template), and just manually specify the document type to either jinja-html or django-html. https://jinja.palletsprojects.com/en/3.0.x/templates/#synopsis
